### PR TITLE
fix: extended value

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -71,7 +71,7 @@ pub enum ExtendedValue {
     List(Vec<ExtendedValue>),
     // key: {}
     Empty(crate::EmptyContent),
-    // key: null
+    // key: null, if key is null, it must be Option::None
     Null(Option<()>),
 }
 
@@ -113,9 +113,9 @@ impl ExtendedValue {
             _ => None,
         }
     }
-    pub fn as_null(self) -> Option<()> {
+    pub fn as_null(self) -> Option<Option<()>> {
         match self {
-            Self::Null(v) => v,
+            Self::Null(v) => Some(v),
             _ => None,
         }
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -69,7 +69,10 @@ pub enum ExtendedValue {
     Bool(bool),
     Map(HashMap<String, ExtendedValue>),
     List(Vec<ExtendedValue>),
+    // key: {}
     Empty(crate::EmptyContent),
+    // key: null
+    Null(Option<()>),
 }
 
 #[allow(dead_code)]
@@ -110,6 +113,12 @@ impl ExtendedValue {
             _ => None,
         }
     }
+    pub fn as_null(self) -> Option<()> {
+        match self {
+            Self::Null(v) => v,
+            _ => None,
+        }
+    }
     pub fn is_str(&self) -> bool {
         matches!(self, Self::Str(_))
     }
@@ -130,6 +139,9 @@ impl ExtendedValue {
     }
     pub fn is_empty(&self) -> bool {
         matches!(self, Self::Empty(_))
+    }
+    pub fn is_null(&self) -> bool {
+        matches!(self, Self::Null(_))
     }
 }
 


### PR DESCRIPTION
add a "null type" for ExtendedValue

```rust
    use walle_core::{ExtendedMap, ExtendedValue, EmptyContent};
    use walle_v11::{Event, event::{EventContent, MessageContent, MessageSub}, message::MessageSegment, utils::GroupSender};

    let test = "{\"test_null_value\":null,\"time\":0,\"self_id\":0,\"post_type\":\"message\",\"message_id\":0,\"user_id\":1,\"message\":[{\"type\":\"text\",\"data\":{\"text\":\"\"}}],\"raw_message\":\"raw\",\"font\":0,\"message_type\":\"group\",\"group_id\":0,\"sender\":{\"user_id\":0,\"nickname\":\"\",\"card\":\"\",\"sex\":\"\",\"age\":0,\"area\":\"\",\"level\":\"\",\"role\":\"\",\"title\":\"\"}}";
    let event_de:Event = serde_json::from_str(test).unwrap();
    println!("{:?}", event_de);
```
将获得到一个找不到对应untagged enum variant的错误